### PR TITLE
feat(api-users): add email and password validations to user schema

### DIFF
--- a/api_users/schema/user_schemas.py
+++ b/api_users/schema/user_schemas.py
@@ -1,0 +1,30 @@
+from marshmallow import fields, validates, ValidationError, Schema
+import re
+
+class UserSchema(Schema):
+    email = fields.String(required=True)
+    password = fields.String(required=True)
+
+    @validates('email')
+    def validate_email(self, value):
+        # Validate email with a regex pattern
+        email_regex = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+        if not re.match(email_regex, value):
+            raise ValidationError('Invalid email address format')
+        if len(value) > 254:
+            raise ValidationError('Email address is too long')
+
+    @validates('password')
+    def validate_password(self, value):
+        # Password must be at least 8 characters long and include
+        # at least one uppercase letter, one lowercase letter, and one number
+        if len(value) < 8:
+            raise ValidationError('Password must be at least 8 characters long')
+        if not any(char.isdigit() for char in value):
+            raise ValidationError('Password must include at least one number')
+        if not any(char.isupper() for char in value):
+            raise ValidationError('Password must include at least one uppercase letter')
+        if not any(char.islower() for char in value):
+            raise ValidationError('Password must include at least one lowercase letter')
+        if len(value) > 64:
+            raise ValidationError('Password must not exceed 64 characters')


### PR DESCRIPTION
### What?  
Added email and password validation to the `UserSchema` class using Marshmallow's validation features.

### Why?  
To ensure data integrity by validating that email addresses follow a correct format and that passwords meet specific security requirements.

### How?  
- Added a `validate_email` method to enforce proper email formatting using a regex and limit the email length to 254 characters.  
- Added a `validate_password` method to enforce the following password rules:
  - Minimum of 8 characters.
  - Must include at least one uppercase letter, one lowercase letter, and one number.
  - Maximum of 64 characters.

### Testing?  
- Validated multiple email and password examples to confirm the rules are enforced.  
- Tested edge cases such as invalid emails and passwords not meeting security standards.

### Anything Else?  
No.