### PR TITLE
hotfix(gitignore): update .gitignore to properly ignore __pycache__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 # .env*
 # python virtual env
 */venv/
-*/__pycache__/
+**/__pycache__/
 *.log


### PR DESCRIPTION
### What?  
Updated the `.gitignore` file to improve the exclusion rules for Python-related directories and files.

### Why?  
To ensure more comprehensive and consistent exclusion of unnecessary files, particularly Python cache directories.

### How?  
- Adjusted the exclusion rule for `__pycache__` to use `**/__pycache__/`, ensuring all instances of `__pycache__` in nested directories are ignored.  
- Kept existing exclusions for virtual environments (`/venv/`) and log files (`*.log`).

### Testing?  
- Verified that all `__pycache__` directories across different levels are ignored.  
- Ensured that the updated `.gitignore` does not accidentally exclude required files.

### Anything Else?  
No.