### PR TITLE
hotfix(api-apps-routes): just a change from 402 to 400

### DIFF
--- a/api_apps/routes/app_routes.py
+++ b/api_apps/routes/app_routes.py
@@ -88,7 +88,7 @@ class AppRoutes(Blueprint):
                 # Validate the input schema using Marshmallow
                 self.app_schema.load(request_data)
             except ValidationError as e:
-                return jsonify({'error': f'Validation failed: {e.messages}'}), 402
+                return jsonify({'error': f'Validation failed: {e.messages}'}), 400
 
             # Call the service to add the app
             service_response = self.app_service.add_app(request_data)


### PR DESCRIPTION
### What?  
- Changed the HTTP status code from **402** to **400** in the `add_app` route for validation errors.  

### Why?  
- To align the response with standard HTTP status code conventions, as **400** indicates a bad request due to client-side validation issues.  

### How?  
- Updated the `jsonify` response in the `add_app` method within `api_apps/routes/app_routes.py`.  

### Testing?  
- Test the `add_app` endpoint with invalid input data to ensure the response now returns **400** instead of **402**.